### PR TITLE
Dynamic event name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  
+  def get_event_name
+    @event_name = ENV['EVENT_NAME'] || "Pittco"
+  end
+  
+  before_filter :get_event_name
+  
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>Insomnia LAN Intranet</title>
+    <title>Pittco LAN Intranet</title>
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= csrf_meta_tags %>
@@ -62,7 +62,7 @@
             <div class="col-md-8 col-md-offset-2">
               <h1 class="brand-heading">
                 <%= image_tag "pittco_logo_header.png" %>
-                Insomnia 
+                <%= @event_name %> 
               </h1>
               <a href="#news" class="btn btn-circle page-scroll">
                 <i class="fa fa-angle-double-down animated"></i>


### PR DESCRIPTION
This would fix #3.

Maybe the event name will eventually come from the database, but it's enough of an environment thing that it should probably come from the environment _for now_.

Note that this is untested, just edited crap on Github itself.
